### PR TITLE
[adguard-home] Inital commit of Adguard-Home DNS blocker

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,6 @@
 name: Lint and Test Charts
 
-on: pull_request
+on: [push]
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -29,4 +29,4 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: install
-#          config: ct.yaml
+          config: ct.yaml

--- a/charts/adguard-home/.helmignore
+++ b/charts/adguard-home/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 appVersion: "v0.8"
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 0.1.0
+version: 1.0.0
 keywords:
   - adguard-home
   - adguard
-  - dbs
-home: https://github.com/dcplaya/billimek-charts/tree/master/charts/adguard-home
+  - dns
+home: https://github.com/billimek/billimek-charts/tree/master/charts/adguard-home
 icon: https://avatars3.githubusercontent.com/u/8361145?s=200&v=4?sanitize=true
 sources:
   - https://github.com/AdguardTeam/AdGuardHome
 maintainers:
-  - name: dcplaya
+  - name: billimek

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+appVersion: "v0.8"
+description: DNS proxy as ad-blocker for local network
+name: adguard-home
+version: 0.1.0
+keywords:
+  - adguard-home
+  - adguard
+  - dbs
+home: https://github.com/dcplaya/billimek-charts/tree/master/charts/adguard-home
+icon: https://avatars3.githubusercontent.com/u/8361145?s=200&v=4?sanitize=true
+sources:
+  - https://github.com/AdguardTeam/AdGuardHome
+maintainers:
+  - name: dcplaya

--- a/charts/adguard-home/OWNERS
+++ b/charts/adguard-home/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dcplaya
+reviewers:
+- dcplaya

--- a/charts/adguard-home/OWNERS
+++ b/charts/adguard-home/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- dcplaya
+- billimek
 reviewers:
-- dcplaya
+- billimek

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -1,0 +1,74 @@
+# DNS proxy as ad-blocker for local network
+
+This is an opinionated helm chart for [blocky](https://github.com/0xERR0R/blocky) 
+
+The default values and container images used in this chart will allow for running in a multi-arch cluster (amd64, arm, arm64)
+
+## TL;DR
+
+```shell
+helm repo add billimek https://billimek.com/billimek-charts/
+helm install billimek/blocky
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name blocky billimek/blocky
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `blocky` deployment:
+
+```console
+helm delete blocky --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/blocky/values.yaml) file. It has several commented out suggested values.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name blocky \
+  --set timeZone="America/New York" \
+    billimek/blocky
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name blocky -f values.yaml billimek/blocky
+```
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 2.2.2 -> 3.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrading from 2.x.x to 3.x.x
+
+Due to the renaming of the service port, an upgrade-in-place will not work.  The following are possible approaches to solve this:
+
+#### Helm force upgrade
+
+```sh
+helm upgrade --force
+```
+
+#### Delete the existing `blocky` service prior to upgrading
+
+```sh
+kubectl delete svc/blocky
+```
+
+#### Remove the existing blocky chart first
+
+This is the 'easiest' approach, but will incur downtime which can be problematic if you rely on blocky for DNS
+

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -1,6 +1,6 @@
 # DNS proxy as ad-blocker for local network
 
-This is an opinionated helm chart for [blocky](https://github.com/0xERR0R/blocky) 
+This is an opinionated helm chart for [adguard-home](https://github.com/AdguardTeam/AdGuardHome)
 
 The default values and container images used in this chart will allow for running in a multi-arch cluster (amd64, arm, arm64)
 
@@ -8,7 +8,7 @@ The default values and container images used in this chart will allow for runnin
 
 ```shell
 helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/blocky
+helm install billimek/adguard-home
 ```
 
 ## Installing the Chart
@@ -16,35 +16,35 @@ helm install billimek/blocky
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name blocky billimek/blocky
+helm install --name adguard-home billimek/adguard-home
 ```
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `blocky` deployment:
+To uninstall/delete the `adguard-home` deployment:
 
 ```console
-helm delete blocky --purge
+helm delete adguard-home --purge
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/blocky/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/adguard-home/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-helm install --name blocky \
+helm install --name adguard-home \
   --set timeZone="America/New York" \
-    billimek/blocky
+    billimek/adguard-home
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name blocky -f values.yaml billimek/blocky
+helm install --name adguard-home -f values.yaml billimek/adguard-home
 ```
 
 ## Upgrading an existing Release to a new major version
@@ -62,13 +62,12 @@ Due to the renaming of the service port, an upgrade-in-place will not work.  The
 helm upgrade --force
 ```
 
-#### Delete the existing `blocky` service prior to upgrading
+#### Delete the existing `adguard-home` services prior to upgrading
 
 ```sh
-kubectl delete svc/blocky
+kubectl delete svc/adguard-home
 ```
 
 #### Remove the existing blocky chart first
 
 This is the 'easiest' approach, but will incur downtime which can be problematic if you rely on blocky for DNS
-

--- a/charts/adguard-home/templates/NOTES.txt
+++ b/charts/adguard-home/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.serviceUDP.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include ".fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.serviceUDP.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "adguard-home.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "adguard-home.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.serviceUDP.port }}
+{{- else if contains "ClusterIP" .Values.serviceUDP.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "adguard-home.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:3000
+{{- end }}

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "adguard-home.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "adguard-home.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "adguard-home.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/adguard-home/templates/config-pvc.yaml
+++ b/charts/adguard-home/templates/config-pvc.yaml
@@ -1,0 +1,29 @@
+
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nzbget.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "nzbget.name" . }}
+    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/adguard-home/templates/config-pvc.yaml
+++ b/charts/adguard-home/templates/config-pvc.yaml
@@ -3,14 +3,14 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "nzbget.fullname" . }}-config
+  name: {{ template "adguard-home.fullname" . }}-config
   {{- if .Values.persistence.config.skipuninstall }}
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "nzbget.name" . }}
-    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -40,7 +40,6 @@ spec:
             - name: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-config{{- end }}
               mountPath: /opt/adguardhome/conf
               readOnly: false
-            {{- end }}
           ports:
             - name: api
               containerPort: 3000

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               mountPath: /opt/adguardhome/conf
               readOnly: false
           ports:
-            - name: api
+            - name: http
               containerPort: 3000
             - name: dns
               containerPort: 53

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -41,9 +41,6 @@ spec:
               mountPath: /opt/adguardhome/conf
               readOnly: false
           ports:
-            - name: test
-              containerPort: 80
-              protocol: TCP
             - name: http
               containerPort: 3000
             - name: dns

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
               value: {{ .Values.timeZone | quote }}
             {{- end }}
           volumeMounts:
-            - name: {{ if .Values.persistence.work.existingClaim }}{{ .Values.persistence.work.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-work{{- end }}
+            - name: work
               mountPath: /opt/adguardhome/work
               readOnly: false
-            - name: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-config{{- end }}
+            - name: config
               mountPath: /opt/adguardhome/conf
               readOnly: false
           ports:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: dns-udp
               containerPort: 53
               protocol: UDP
-            {{- if .Values.dhcp.enabled }}
+            {{- if .Values.serviceDHCP.enabled }}
             - name: dhcp-server-udp
               containerPort: 67
               protocol: UDP

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -34,12 +34,11 @@ spec:
               value: {{ .Values.timeZone | quote }}
             {{- end }}
           volumeMounts:
-            - name: work
+            - name: {{ if .Values.persistence.work.existingClaim }}{{ .Values.persistence.work.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-work{{- end }}
               mountPath: /opt/adguardhome/work
 #              subPath: config.yml
               readOnly: false
-            {{- range $name, $value := .Values.extraLists }}
-            - name: config
+            - name: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-config{{- end }}
               mountPath: /opt/adguardhome/conf
 #              subPath: {{ $name }}
               readOnly: false

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicas }}
+#  replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
         app.kubernetes.io/name: {{ include "adguard-home.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
-#        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -29,9 +29,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if .Values.timeZone }}
+            {{- if .Values.timezone }}
             - name: TZ
-              value: {{ .Values.timeZone | quote }}
+              value: {{ .Values.timezone | quote }}
             {{- end }}
           volumeMounts:
             - name: work
@@ -65,25 +65,6 @@ spec:
               containerPort: 853
               protocol: TCP
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /
-              port: api
-            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-          readinessProbe:
-            httpGet:
-              path: /
-              port: api
-            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-          startupProbe:
-            httpGet:
-              path: /
-              port: api
-            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
-            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -36,11 +36,9 @@ spec:
           volumeMounts:
             - name: {{ if .Values.persistence.work.existingClaim }}{{ .Values.persistence.work.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-work{{- end }}
               mountPath: /opt/adguardhome/work
-#              subPath: config.yml
               readOnly: false
             - name: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-config{{- end }}
               mountPath: /opt/adguardhome/conf
-#              subPath: {{ $name }}
               readOnly: false
             {{- end }}
           ports:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
               mountPath: /opt/adguardhome/conf
               readOnly: false
           ports:
+            - name: test
+              containerPort: 80
+              protocol: TCP
             - name: http
               containerPort: 3000
             - name: dns

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-#  replicas: {{ .Values.replicas }}
+  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adguard-home.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+#        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if .Values.timeZone }}
+            - name: TZ
+              value: {{ .Values.timeZone | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: work
+              mountPath: /opt/adguardhome/work
+#              subPath: config.yml
+              readOnly: false
+            {{- range $name, $value := .Values.extraLists }}
+            - name: config
+              mountPath: /opt/adguardhome/conf
+#              subPath: {{ $name }}
+              readOnly: false
+            {{- end }}
+          ports:
+            - name: api
+              containerPort: 3000
+            - name: dns
+              containerPort: 53
+              protocol: TCP
+            - name: dns-udp
+              containerPort: 53
+              protocol: UDP
+            {{- if .Values.dhcp.enabled }}
+            - name: dhcp-server-udp
+              containerPort: 67
+              protocol: UDP
+            - name: dhcp-client-tcp
+              containerPort: 68
+              protocol: TCP
+            - name: dhcp-client-udp
+              containerPort: 68
+              protocol: UDP
+            {{- end }}
+            {{- if .Values.serviceDNSOverTLS.enabled }}
+            - name: dns-over-tls
+              containerPort: 853
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: api
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: api
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: api
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: config
+      {{- if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-config{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: work
+      {{- if .Values.persistence.work.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.work.existingClaim }}{{ .Values.persistence.work.existingClaim }}{{- else }}{{ template "adguard-home.fullname" . }}-work{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/adguard-home/templates/ingress.yaml
+++ b/charts/adguard-home/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "adguard-home.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/adguard-home/templates/service-dhcp.yaml
+++ b/charts/adguard-home/templates/service-dhcp.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceDHCP.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-dhcp
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceDHCP.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDHCP.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDHCP.type }}
+  {{- if .Values.serviceDHCP.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceDHCP.loadBalancerIP }}
+  {{- end }}
+  externalTrafficPolicy: {{ .Values.serviceDHCP.externalTrafficPolicy }}
+  ports:
+    - port: 67
+      targetPort: dhcp-server-udp
+      protocol: UDP
+      name: dhcp-server-udp
+    - port: 68
+      targetPort: dhcp-client-tcp
+      protocol: TCP
+      name: dhcp-client-tcp
+    - port: 68
+      targetPort: dhcp-client-udp
+      protocol: UDP
+      name: dhcp-client-udp
+  selector:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/adguard-home/templates/service-dns-over-tls.yaml
+++ b/charts/adguard-home/templates/service-dns-over-tls.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceDNSOverTLS.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-tcp
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceDNSOverTLS.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDNSOverTLS.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDNSOverTLS.type }}
+  {{- if .Values.serviceDNSOverTLS.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceDNSOverTLS.loadBalancerIP }}
+  {{- end }}
+  externalTrafficPolicy: {{ .Values.serviceDNSOverTLS.externalTrafficPolicy }}
+  ports:
+    - port: 853
+      targetPort: dns-over-tls
+      protocol: TCP
+      name: dns-over-tls
+  selector:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/adguard-home/templates/service-dns-over-tls.yaml
+++ b/charts/adguard-home/templates/service-dns-over-tls.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "adguard-home.fullname" . }}-tcp
+  name: {{ include "adguard-home.fullname" . }}-dns-over-tls
   labels:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}
     helm.sh/chart: {{ include "adguard-home.chart" . }}

--- a/charts/adguard-home/templates/service-tcp.yaml
+++ b/charts/adguard-home/templates/service-tcp.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceTCP.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-tcp
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceTCP.annotations }}
+  annotations:
+{{ toYaml .Values.serviceTCP.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceTCP.type }}
+  {{- if .Values.serviceTCP.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceTCP.loadBalancerIP }}
+  {{- end }}
+  externalTrafficPolicy: {{ .Values.serviceTCP.externalTrafficPolicy }}
+  ports:
+    - port: 53
+      targetPort: dns
+      protocol: TCP
+      name: dns
+  selector:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/adguard-home/templates/service-udp.yaml
+++ b/charts/adguard-home/templates/service-udp.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceUDP.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-udp
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceUDP.annotations }}
+  annotations:
+{{ toYaml .Values.serviceUDP.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceUDP.type }}
+  {{- if .Values.serviceUDP.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceUDP.loadBalancerIP }}
+  {{- end }}
+  externalTrafficPolicy: {{ .Values.serviceUDP.externalTrafficPolicy }}
+  ports:
+    - port: 53
+      targetPort: dns-udp
+      protocol: UDP
+      name: dns-udp
+  selector:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -37,9 +37,9 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-  - name: api
+  - name: http
     port: 3000
-    targetPort: api
+    targetPort: http
   selector:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -40,9 +40,6 @@ spec:
   - name: http
     port: 3000
     targetPort: http
-  - name: test
-    port: 80
-    targetPort: test
   selector:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -12,35 +12,16 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
-{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
-  type: ClusterIP
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
-  {{end}}
-{{- else if eq .Values.service.type "LoadBalancer" }}
   type: {{ .Values.service.type }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
-  {{- end -}}
-{{- else }}
-  type: {{ .Values.service.type }}
-{{- end }}
-{{- if .Values.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
-  {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
-  {{- end }}
   ports:
-  - name: http
-    port: 3000
-    protocol: TCP
-    targetPort: http
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -40,6 +40,10 @@ spec:
   - name: http
     port: 3000
     targetPort: http
+  ports:
+  - name: test
+    port: 80
+    targetPort: test
   selector:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - name: api
+    port: 3000
+    targetPort: api
+  selector:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -39,6 +39,7 @@ spec:
   ports:
   - name: http
     port: 3000
+    protocol: TCP
     targetPort: http
   selector:
     app.kubernetes.io/name: {{ include "adguard-home.name" . }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -40,7 +40,6 @@ spec:
   - name: http
     port: 3000
     targetPort: http
-  ports:
   - name: test
     port: 80
     targetPort: test

--- a/charts/adguard-home/templates/servicemonitor.yaml
+++ b/charts/adguard-home/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/name: {{ include "adguard-home.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
-  - port: api
+  - port: http
     interval: 30s
     path: /
 {{- end }}

--- a/charts/adguard-home/templates/servicemonitor.yaml
+++ b/charts/adguard-home/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "adguard-home.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
+  {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+  - port: api
+    interval: 30s
+    path: /
+{{- end }}

--- a/charts/adguard-home/templates/work-pvc.yaml
+++ b/charts/adguard-home/templates/work-pvc.yaml
@@ -1,0 +1,29 @@
+
+{{- if and .Values.persistence.work.enabled (not .Values.persistence.work.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nzbget.fullname" . }}-work
+  {{- if .Values.persistence.work.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "nzbget.name" . }}
+    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.work.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.work.size | quote }}
+{{- if .Values.persistence.work.storageClass }}
+{{- if (eq "-" .Values.persistence.work.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.work.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/adguard-home/templates/work-pvc.yaml
+++ b/charts/adguard-home/templates/work-pvc.yaml
@@ -3,14 +3,14 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "nzbget.fullname" . }}-work
+  name: {{ template "adguard-home.fullname" . }}-work
   {{- if .Values.persistence.work.skipuninstall }}
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "nzbget.name" . }}
-    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/name: {{ include "adguard-home.name" . }}
+    helm.sh/chart: {{ include "adguard-home.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -13,7 +13,56 @@ replicas: 1
 timeZone: "UTC"
 
 persistence:
-  ## need stuff here!
+  config:
+    enabled: true
+    ## adguard-home configuration data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+  work:
+    enabled: true
+    ## adguard-home media volume configuration
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 
 # Probes configuration
 probes:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -85,7 +85,7 @@ service:
 serviceTCP:
   enabled: false
   type: NodePort
-#  externalTrafficPolicy: Local
+  # externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -95,7 +95,7 @@ serviceTCP:
 serviceUDP:
   enabled: true
   type: NodePort
-#  externalTrafficPolicy: Local
+  # externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -106,7 +106,7 @@ serviceDNSOverTLS:
   enabled: false
   ## Enable if you use AdGuard as a DNS over TLS/HTTPS server
   type: NodePort
-#  externalTrafficPolicy: Local
+  # externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -117,7 +117,7 @@ serviceDHCP:
   enabled: false
   ## Enable if you use AdGuard as a DHCP Server
   type: NodePort
-#  externalTrafficPolicy: Local
+  # externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -150,7 +150,7 @@ persistence:
     # existingClaim: your-claim
     # subPath: some-subpath
     accessMode: ReadWriteOnce
-    size: 10Gi
+    size: 20Mi
     ## Do not delete the pvc upon helm uninstall
     skipuninstall: false
   work:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -85,7 +85,7 @@ service:
 serviceTCP:
   enabled: false
   type: NodePort
-  externalTrafficPolicy: Local
+#  externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -95,7 +95,7 @@ serviceTCP:
 serviceUDP:
   enabled: true
   type: NodePort
-  externalTrafficPolicy: Local
+#  externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -106,7 +106,7 @@ serviceDNSOverTLS:
   enabled: false
   ## Enable if you use AdGuard as a DNS over TLS/HTTPS server
   type: NodePort
-  externalTrafficPolicy: Local
+#  externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
@@ -117,7 +117,7 @@ serviceDHCP:
   enabled: false
   ## Enable if you use AdGuard as a DHCP Server
   type: NodePort
-  externalTrafficPolicy: Local
+#  externalTrafficPolicy: Local
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -1,5 +1,3 @@
-replicaCount: 1
-
 image:
   repository: adguard/adguardhome
   tag: v0.102.0

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 
 replicas: 1
 
-timeZone: "UTC"
+timezone: "UTC"
 
 persistence:
   config:
@@ -26,7 +26,7 @@ persistence:
     ## the existingClaim variable
     # existingClaim: your-claim
     accessMode: ReadWriteOnce
-    size: 10Gi
+    size: 100Mi
     ## Do not delete the pvc upon helm uninstall
     skipuninstall: false
   work:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -1,0 +1,147 @@
+replicaCount: 1
+
+image:
+  repository: adguard/adguardhome
+  tag: v0.102.0
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicas: 1
+
+timeZone: "UTC"
+
+persistence:
+  ## need stuff here!
+
+# Probes configuration
+probes:
+  liveness:
+    failureThreshold: 5
+    periodSeconds: 10
+  readiness:
+    failureThreshold: 5
+    periodSeconds: 10
+  startup:
+    initialDelaySeconds: 5
+    failureThreshold: 30
+    periodSeconds: 10
+
+service:
+  type: ClusterIP
+  # externalTrafficPolicy: Local
+  # loadBalancerIP: ""
+    # a fixed LoadBalancer IP
+  annotations: {}
+    # metallb.universe.tf/address-pool: network-services
+    # metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+serviceTCP:
+  enabled: false
+  type: NodePort
+  externalTrafficPolicy: Local
+  loadBalancerIP: ""
+    # a fixed LoadBalancer IP
+  annotations: {}
+    # metallb.universe.tf/address-pool: network-services
+    # metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+serviceUDP:
+  enabled: true
+  type: NodePort
+  externalTrafficPolicy: Local
+  loadBalancerIP: ""
+    # a fixed LoadBalancer IP
+  annotations: {}
+    # metallb.universe.tf/address-pool: network-services
+    # metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+serviceDNSOverTLS:
+  enabled: false
+  ## Enable if you use AdGuard as a DHCP Server
+  type: NodePort
+  externalTrafficPolicy: Local
+  loadBalancerIP: ""
+    # a fixed LoadBalancer IP
+  annotations: {}
+    # metallb.universe.tf/address-pool: network-services
+    # metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+serviceDHCP:
+  enabled: false
+  ## Enable if you use AdGuard as a DHCP Server
+  type: NodePort
+  externalTrafficPolicy: Local
+  loadBalancerIP: ""
+    # a fixed LoadBalancer IP
+  annotations: {}
+    # metallb.universe.tf/address-pool: network-services
+    # metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+
+## Pod Annotations
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "api"
+
+persistence:
+  config:
+    enabled: true
+    ## adguard-home configuration data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+  work:
+    enabled: true
+    ## adguard-home work volume configuration
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  memory: 500Mi
+  # requests:
+  #  cpu: 50m
+  #  memory: 275Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -59,7 +59,7 @@ serviceUDP:
 
 serviceDNSOverTLS:
   enabled: false
-  ## Enable if you use AdGuard as a DHCP Server
+  ## Enable if you use AdGuard as a DNS over TLS/HTTPS server
   type: NodePort
   externalTrafficPolicy: Local
   loadBalancerIP: ""

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -6,8 +6,6 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-replicas: 1
-
 timezone: "UTC"
 
 persistence:

--- a/charts/esphome/.helmignore
+++ b/charts/esphome/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/esphome/Chart.yaml
+++ b/charts/esphome/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: 1.14.5
+description: ESPHome
+name: esphome
+version: 1.0.0
+keywords:
+- esphome
+home: https://github.com/billimek/billimek-charts/tree/master/charts/esphome
+icon: https://esphome.io/_images/logo-text.svg
+sources:
+- https://github.com/esphome/esphome
+maintainers:
+- name: billimek
+  email: jeff@billimek.com

--- a/charts/esphome/OWNERS
+++ b/charts/esphome/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- billimek
+reviewers:
+- billimek

--- a/charts/esphome/README.md
+++ b/charts/esphome/README.md
@@ -1,0 +1,113 @@
+# ESPHome
+
+This is a helm chart for [ESPHome](https://esphome.io)
+
+## TL;DR;
+
+```shell
+helm repo add billimek https://billimek.com/billimek-charts/
+helm install billimek/esphome
+```
+
+## Introduction
+
+This code is adapted for [the official esphome docker image](https://hub.docker.com/r/esphome/esphome/)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```shell
+helm install --name my-release billimek/esphome
+```
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```shell
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the ESPHome chart and their default values.
+
+| Parameter                  | Description                         | Default                                                 |
+|----------------------------|-------------------------------------|---------------------------------------------------------|
+| `image.repository`         | Image repository | `esphome/esphome` |
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/esphome/esphome/tags/).| `0.14.5`|
+| `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
+| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
+| `probes.liveness.enabled`  | Use the livenessProbe?  | `true` |
+| `probes.liveness.scheme `  | Specify liveness `scheme` parameter for the deployment  | `HTTP` |
+| `probes.liveness.initialDelaySeconds`  | Specify liveness `initialDelaySeconds` parameter for the deployment  | `60` |
+| `probes.liveness.failureThreshold`     | Specify liveness `failureThreshold` parameter for the deployment     | `5`  |
+| `probes.liveness.timeoutSeconds`       | Specify liveness `timeoutSeconds` parameter for the deployment       | `10` |
+| `probes.readiness.enabled`  | Use the readinessProbe?  | `true` |
+| `probes.readiness.scheme `  | Specify readiness `scheme` parameter for the deployment  | `HTTP` |
+| `probes.readiness.initialDelaySeconds` | Specify readiness `initialDelaySeconds` parameter for the deployment | `60` |
+| `probes.readiness.failureThreshold`    | Specify readiness `failureThreshold` parameter for the deployment    | `5`  |
+| `probes.readiness.timeoutSeconds`      | Specify readiness `timeoutSeconds` parameter for the deployment      | `10` |
+| `probes.startup.enabled`  | Use the startupProbe? (new in kubernetes 1.16)  | `false` |
+| `probes.startup.scheme `  | Specify startup `scheme` parameter for the deployment  | `HTTP` |
+| `probes.startup.failureThreshold`    | Specify startup `failureThreshold` parameter for the deployment    | `5`  |
+| `probes.startup.periodSeconds`      | Specify startup `periodSeconds` parameter for the deployment      | `10` |
+| `service.type`             | Kubernetes service type for the esphome GUI | `ClusterIP` |
+| `service.port`             | Kubernetes port where the esphome GUI is exposed| `6052` |
+| `service.portName`         | Kubernetes port name where the esphome GUI is exposed | `api` |
+| `service.additionalPorts`  | Add additional ports exposed by the esphome container integrations. Example homematic needs to expose a proxy port | `{}` |
+| `service.annotations`      | Service annotations for the esphome GUI | `{}` |
+| `service.clusterIP`   | Cluster IP for the esphom GUI | `` |
+| `service.externalIPs`   | External IPs for the esphome GUI | `[]` |
+| `service.loadBalancerIP`   | Loadbalancer IP for the esphome GUI | `` |
+| `service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the esphome GUI | `[]` |
+| `service.publishNotReadyAddresses`   | Set to true if the notReadyAddresses should be published | `false` |
+| `service.externalTrafficPolicy`   | Loadbalancer externalTrafficPolicy | `` |
+| `hostNetwork`              | Enable hostNetwork - might be needed for discovery to work | `false` |
+| `service.nodePort`   | nodePort to listen on for the esphome GUI | `` |
+| `ingress.enabled`              | Enables Ingress | `false` |
+| `ingress.annotations`          | Ingress annotations | `{}` |
+| `ingress.path`                 | Ingress path | `/` |
+| `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |
+| `ingress.tls`                  | Ingress TLS configuration | `[]` |
+| `persistence.enabled`      | Use persistent volume to store data | `true` |
+| `persistence.size`         | Size of persistent volume claim | `5Gi` |
+| `persistence.existingClaim`| Use an existing PVC to persist data | `nil` |
+| `persistence.hostPath`| The path to the config directory on the host, instead of a PVC | `nil` |
+| `persistence.storageClass` | Type of persistent volume claim | `-` |
+| `persistence.accessMode`  | Persistence access modes | `ReadWriteMany` |
+| `hostMounts`        | Array of host directories to mount; can be used for devices | [] |
+| `hostMounts.name`   | Name of the volume | `nil` |
+| `hostMounts.hostPath` | The path on the host machine | `nil` |
+| `hostMounts.mountPath` | The path at which to mount (optional; assumed same as hostPath) | `nil` |
+| `hostMounts.type` | The type to mount (optional, i.e., `Directory`) | `nil` |
+| `extraEnv`          | Extra ENV vars to pass to the esphome container | `{}` |
+| `extraEnvSecrets`   | Extra env vars to pass to the esphome container from k8s secrets - see `values.yaml` for an example | `{}` |
+| `resources`                | CPU/Memory resource requests/limits or the esphome GUI | `{}` |
+| `nodeSelector`             | Node labels for pod assignment or the esphome GUI | `{}` |
+| `tolerations`              | Toleration labels for pod assignment or the esphome GUI | `[]` |
+| `affinity`                 | Affinity settings for pod assignment or the esphome GUI | `{}` |
+| `podAnnotations`            | Key-value pairs to add as pod annotations  | `{}` |
+| `extraVolumes`            | Any extra volumes to define for the pod  | `{}` |
+| `extraVolumeMounts`       | Any extra volumes mounts to define for each container of the pod  | `{}` |
+
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```shell
+helm install --name my-release \
+  --set image.tag=latest \
+    billimek/esphome
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```shell
+helm install --name my-release -f values.yaml billimek/esphome
+```
+
+Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/esphome/templates/NOTES.txt
+++ b/charts/esphome/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "esphome.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "esphome.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "esphome.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "esphome.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/esphome/templates/_helpers.tpl
+++ b/charts/esphome/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "esphome.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "esphome.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "esphome.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/esphome/templates/deployment.yaml
+++ b/charts/esphome/templates/deployment.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "esphome.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "esphome.name" . }}
+    helm.sh/chart: {{ include "esphome.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: {{ .Values.strategyType }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "esphome.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "esphome.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- range .Values.service.additionalPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .targetPort }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: api
+              scheme: {{ .Values.probes.liveness.scheme }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: api
+              scheme: {{ .Values.probes.readiness.scheme }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: api
+              scheme: {{ .Values.probes.startup.scheme }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          {{- end }}
+          env:
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+            {{- range $name, $opts := .Values.extraEnvSecrets }}
+            - name: {{ $name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $opts.secret }}
+                  key: {{ $opts.key }}
+            {{- end }}
+          envFrom:
+          {{- range .Values.extraSecretForEnvFrom }}
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /config
+            name: config
+          {{- range .Values.hostMounts }}
+          {{- if .mountPath }}
+          - mountPath: {{ .mountPath }}
+          {{- else }}
+          - mountPath: {{ .hostPath }}
+          {{- end }}
+            name: {{ .name }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
+          {{- if .Values.usePodSecurityContext }}
+          securityContext:
+            runAsUser: {{ default 0 .Values.runAsUser }}
+          {{- if and (.Values.runAsUser) (.Values.fsGroup) }}
+          {{- if not (eq .Values.runAsUser 0.0) }}
+            fsGroup: {{ .Values.fsGroup }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.hostMounts }}
+          securityContext:
+            privileged: true
+          {{- end }}
+      volumes:
+      - name: config
+      {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.hostPath }}
+        hostPath:
+          path: {{.Values.persistence.hostPath}}
+          type: Directory
+        {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "esphome.fullname" . }}{{- end }}
+        {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- range .Values.hostMounts }}
+      - name: {{ .name }}
+        hostPath:
+          path: {{.hostPath}}
+          {{- if .type }}
+          type: {{ .type }}
+          {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/esphome/templates/ingress.yaml
+++ b/charts/esphome/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "esphome.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "esphome.name" . }}
+    helm.sh/chart: {{ include "esphome.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/charts/esphome/templates/pvc.yaml
+++ b/charts/esphome/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "esphome.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "esphome.name" . }}
+    helm.sh/chart: {{ include "esphome.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/esphome/templates/service.yaml
+++ b/charts/esphome/templates/service.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "esphome.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "esphome.name" . }}
+    helm.sh/chart: {{ include "esphome.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  publishNotReadyAddresses: {{ .Values.service.publishNotReadyAddresses }}
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: 6052
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+{{- if .Values.service.additionalPorts }}
+    {{- .Values.service.additionalPorts | toYaml | indent 4 }}
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "esphome.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/esphome/values.yaml
+++ b/charts/esphome/values.yaml
@@ -1,0 +1,154 @@
+# Default values for esphome.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: esphome/esphome
+  tag: 1.14.5
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
+# Probes configuration
+probes:
+  liveness:
+    enabled: true
+    scheme: HTTP
+    initialDelaySeconds: 60
+    failureThreshold: 5
+    timeoutSeconds: 10
+  readiness:
+    enabled: true
+    scheme: HTTP
+    initialDelaySeconds: 60
+    failureThreshold: 5
+    timeoutSeconds: 10
+  startup:
+    enabled: false
+    scheme: HTTP
+    failureThreshold: 30
+    periodSeconds: 10
+service:
+  type: ClusterIP
+  port: 6052
+  portName: api
+  additionalPorts: []
+  # - name: homematicproxy
+  #   port: 2001
+  #   targetPort: 2001
+  annotations: {}
+  labels: {}
+  clusterIP: ""
+  ## List of IP addresses at which the hass-configurator service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  # nodePort: 30000
+  publishNotReadyAddresses: false
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - esphome.local
+  tls: []
+  #  - secretName: esphome-tls
+  #    hosts:
+  #      - esphome.local
+
+hostNetwork: false
+
+persistence:
+  enabled: true
+  ## esphome data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC using
+  ## the existingClaim variable
+  # existingClaim: your-claim
+  ##
+  ## If you want to use a volume on the host machine instead of a PVC:
+  # hostPath: /path/to/the/config/folder
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+## Additional hass container environment variable
+## For instance to add a http_proxy
+##
+extraEnv: {}
+
+## Additional hass container environment variable from k8s secrets
+## For instance to add a password
+## can use `!env_var` in the esphome configuration to reference these variables
+extraEnvSecrets:
+  # Example
+  # This will set ${MQTT_PASSWORD} to the 'password' key from the 'mqtt' secret
+  # MQTT_PASSWORD:
+  #   secret: mqtt
+  #   key: password
+
+## If you'd like to provide your own Kubernetes Secret object instead of passing your values
+## individually, pass in the name of a created + populated Secret.
+## All secrets will be mounted as environment variables, with each key/value mapping to a
+## corresponding environment variable.
+##
+extraSecretForEnvFrom: []
+# - esphome-secrets
+
+# Enable pod security context (must be `true` if runAsUser or fsGroup are set)
+usePodSecurityContext: true
+# Set runAsUser to 1000 to let esphome run as non-root user.
+# When setting runAsUser to a different value than 0 also set fsGroup to the same value:
+# runAsUser: <defaults to 0>
+# fsGroup: <will be omitted in deployment if runAsUser is 0>
+
+# Mount devices or folders from the host machine. Can be used for USB device mounting.
+hostMounts: []
+  # Example
+  # - name: zha
+  #   hostPath: /dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6120245D-if01-port0
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}
+
+# Any extra volumes to define for the pod
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+
+# Any extra volume mounts to define for the containers
+extraVolumeMounts: []
+#   - name: example-name
+#     mountPath: /path/in/container

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.111.4
 description: Home Assistant
 name: home-assistant
-version: 1.1.0
+version: 1.1.1
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.111.4
 description: Home Assistant
 name: home-assistant
-version: 1.1.1
+version: 1.2.0
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.111.4
 description: Home Assistant
 name: home-assistant
-version: 1.2.0
+version: 1.1.0
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.111.4
 description: Home Assistant
 name: home-assistant
-version: 1.1.1
+version: 1.1.2
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -371,7 +371,8 @@ spec:
           args:
 #          - '-c'
           {{- range .Values.socat.devices }}
-          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave tcp:{{ .ip }}:{{ .port }},forever,interval=10'
+          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave'
+          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -371,11 +371,11 @@ spec:
           args:
           - '-c'
           {{- range .Values.socat.devices }}
-          - 'socat pty,link={{ .Values.socat.devices.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.ip }}:{{ .Values.socat.devices.port }},forever,interval=10,fork'
+          - 'socat pty,link={{ .Values.socat.devices.name.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.name.ip }}:{{ .Values.socat.devices.name.port }},forever,interval=10,fork'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .Values.socat.devices.mountPath }}
+          - mountPath: {{ .Values.socat.devices.name.mountPath }}
             name: {{ .Values.socat.devices.name }}
           {{- end }}
           securityContext:
@@ -383,7 +383,6 @@ spec:
           {{- if and (.Values.runAsUser) (.Values.fsGroup) }}
           {{- if not (eq .Values.runAsUser 0.0) }}
              fsGroup: {{ .Values.fsGroup }}
-          {{- end }}
           {{- end }}
           {{- end }}
         {{- end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -367,12 +367,12 @@ spec:
         - name: socat
           image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
           imagePullPolicy: {{ .Values.socat.image.pullPolicy }}
-          command: ["/bin/sh"]
-          args:
-          - '-c'
-          {{- range .Values.socat.devices }}
-          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10'
-          {{- end }}
+#          command: ["/bin/sh"]
+#          args:
+#          - '-c'
+#          {{- range .Values.socat.devices }}
+#          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave tcp:{{ .ip }}:{{ .port }},forever,interval=10'
+#          {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
           - mountPath: /socat # {{ .mountPath }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -367,12 +367,12 @@ spec:
         - name: socat
           image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
           imagePullPolicy: {{ .Values.socat.image.pullPolicy }}
-          command: ["/bin/sh"]
-#          args:
+#          command: ["/bin/sh"]
+          args:
 #          - '-c'
-#          {{- range .Values.socat.devices }}
-#          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave tcp:{{ .ip }}:{{ .port }},forever,interval=10'
-#          {{- end }}
+          {{- range .Values.socat.devices }}
+          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave tcp:{{ .ip }}:{{ .port }},forever,interval=10'
+          {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
           - mountPath: /socat # {{ .mountPath }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -70,14 +70,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.cmdOverride.enabled }}
-#          command: ["socat"]
-#          args: ["pty,link=/dev/ttyUSB0,raw,user=0,group=0,mode=777", "tcp:ser2sock-zigbee.home-automation.svc:10000"]
-          command: ["sh"]
-          args:
-          - "-c"
-          - {{ .Values.cmdOverride.shellArgs }}
-          {{- end }}
           ports:
             - name: api
               containerPort: {{ .Values.service.port }}
@@ -153,6 +145,10 @@ spec:
           {{- end }}
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
+          {{- range .Values.socat.devices }}
+          - mountPath: {{ .Values.socat.devices.name.mountPath }}
+            name: {{ .Values.socat.devices.name }}
+          {{- end }}
           securityContext:
             runAsUser: {{ default 0 .Values.runAsUser }}
           {{- if and (.Values.runAsUser) (.Values.fsGroup) }}
@@ -367,6 +363,30 @@ spec:
           resources:
 {{ toYaml .Values.appdaemon.resources | indent 12 }}
         {{- end }}
+        {{- if .Values.socat.enabled }}
+        - name: socat
+          image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
+          imagePullPolicy: {{ .Values.socat.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args:
+          - '-c'
+          {{- range .Values.socat.devices }}
+          - 'socat pty,link={{ .Values.socat.devices.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.ip }}:{{ .Values.socat.devices.port }},forever,interval=10,fork'
+          {{- end }}
+          volumeMounts:
+          {{- range .Values.socat.devices }}
+          - mountPath: {{ .Values.socat.devices.mountPath }}
+            name: {{ .Values.socat.devices.name }}
+          {{- end }}
+          securityContext:
+            runAsUser: {{ default 0 .Values.runAsUser }}
+          {{- if and (.Values.runAsUser) (.Values.fsGroup) }}
+          {{- if not (eq .Values.runAsUser 0.0) }}
+             fsGroup: {{ .Values.fsGroup }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
       volumes:
       - name: config
       {{- if .Values.persistence.enabled }}
@@ -399,6 +419,13 @@ spec:
         secret:
           defaultMode: 256
           secretName: {{ .Values.git.secret }}
+      {{ end }}
+      {{- if .Values.socat.enabled }}
+      {{- range .Values.socat.devices }}
+      - name: {{ .Values.socat.devices.name }}
+        defaultMode: 0555
+        emtpyDir: { }
+      {{- end }}
       {{ end }}
       {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
     {{- with .Values.nodeSelector }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .mountPath }}
+          - mountPath: /dev # {{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:
@@ -375,7 +375,7 @@ spec:
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .mountPath }}
+          - mountPath: /dev # {{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:
@@ -422,7 +422,6 @@ spec:
       {{- if .Values.socat.enabled }}
       {{- range .Values.socat.devices }}
       - name: {{ .name }}
-#        defaultMode: 0555
         emptyDir: { }
       {{- end }}
       {{ end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -422,7 +422,8 @@ spec:
       {{- if .Values.socat.enabled }}
       {{- range .Values.socat.devices }}
       - name: {{ .name }}
-        emtpyDir: { }
+#        defaultMode: 0555
+        emptyDir: { }
       {{- end }}
       {{ end }}
       {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -421,7 +421,7 @@ spec:
       {{ end }}
       {{- if .Values.socat.enabled }}
       {{- range .Values.socat.devices }}
-      - name: {{ .Values.socat.devices.name }}
+      - name: {{ .name }}
         defaultMode: 0555
         emtpyDir: { }
       {{- end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -371,7 +371,7 @@ spec:
           args:
 #          - '-c'
           {{- range .Values.socat.devices }}
-          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777,wait-slave'
+          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777'
           - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
           {{- end }}
           volumeMounts:

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           {{- range .Values.socat.devices }}
-          - mountPath: /socat{{ .mountPath }}
+          - mountPath: /socat # {{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:
@@ -375,7 +375,7 @@ spec:
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: /socat{{ .mountPath }}
+          - mountPath: /socat # {{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -146,8 +146,8 @@ spec:
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .Values.socat.devices.mountPath }}
-            name: {{ .Values.socat.devices.name }}
+          - mountPath: {{ .mountPath }}
+            name: {{ .name }}
           {{- end }}
           securityContext:
             runAsUser: {{ default 0 .Values.runAsUser }}
@@ -371,12 +371,12 @@ spec:
           args:
           - '-c'
           {{- range .Values.socat.devices }}
-          - 'socat pty,link={{ .Values.socat.devices.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.ip }}:{{ .Values.socat.devices.port }},forever,interval=10,fork'
+          - 'socat pty,link={{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .Values.socat.devices.mountPath }}
-            name: {{ .Values.socat.devices.name }}
+          - mountPath: {{ .mountPath }}
+            name: {{ .name }}
           {{- end }}
           securityContext:
             runAsUser: {{ default 0 .Values.runAsUser }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -367,7 +367,7 @@ spec:
         - name: socat
           image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
           imagePullPolicy: {{ .Values.socat.image.pullPolicy }}
-#          command: ["/bin/sh"]
+          command: ["/bin/sh"]
 #          args:
 #          - '-c'
 #          {{- range .Values.socat.devices }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -373,7 +373,7 @@ spec:
           {{- range .Values.socat.devices }}
           - '-dd'
           - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777'
-          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
+          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -371,6 +371,7 @@ spec:
           args:
 #          - '-c'
           {{- range .Values.socat.devices }}
+          - '-dd'
           - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777'
           - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
           {{- end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -422,7 +422,6 @@ spec:
       {{- if .Values.socat.enabled }}
       {{- range .Values.socat.devices }}
       - name: {{ .name }}
-        defaultMode: 0555
         emtpyDir: { }
       {{- end }}
       {{ end }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -371,7 +371,7 @@ spec:
           args:
           - '-c'
           {{- range .Values.socat.devices }}
-          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
+          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .Values.socat.devices.name.mountPath }}
+          - mountPath: {{ .Values.socat.devices.mountPath }}
             name: {{ .Values.socat.devices.name }}
           {{- end }}
           securityContext:
@@ -371,11 +371,11 @@ spec:
           args:
           - '-c'
           {{- range .Values.socat.devices }}
-          - 'socat pty,link={{ .Values.socat.devices.name.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.name.ip }}:{{ .Values.socat.devices.name.port }},forever,interval=10,fork'
+          - 'socat pty,link={{ .Values.socat.devices.mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .Values.socat.devices.ip }}:{{ .Values.socat.devices.port }},forever,interval=10,fork'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: {{ .Values.socat.devices.name.mountPath }}
+          - mountPath: {{ .Values.socat.devices.mountPath }}
             name: {{ .Values.socat.devices.name }}
           {{- end }}
           securityContext:

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           {{- range .Values.socat.devices }}
-          - mountPath: /dev # {{ .mountPath }}
+          - mountPath: /socat{{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:
@@ -371,11 +371,11 @@ spec:
           args:
           - '-c'
           {{- range .Values.socat.devices }}
-          - 'socat pty,link={{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
+          - 'socat pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777 tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}
-          - mountPath: /dev # {{ .mountPath }}
+          - mountPath: /socat{{ .mountPath }}
             name: {{ .name }}
           {{- end }}
           securityContext:

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -373,7 +373,7 @@ spec:
           {{- range .Values.socat.devices }}
           - '-dd'
           - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777'
-          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
+          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10,fork'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -372,8 +372,8 @@ spec:
 #          - '-c'
           {{- range .Values.socat.devices }}
           - '-dd'
-          - 'pty,link=/socat{{ .mountPath }},raw,user=0,group=0,mode=777'
-          - 'tcp:{{ .ip }}:{{ .port }},forever,interval=10'
+          - 'pty,link=/dev{{ .mountPath }},raw,user=0,group=0,mode=777'
+          - 'tcp:{{ .ip }}:{{ .port }}' # ',forever,interval=10'
           {{- end }}
           volumeMounts:
           {{- range .Values.socat.devices }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -336,9 +336,10 @@ socat:
     pullPolicy: IfNotPresent
 
   ## ip can be a domain name or actual IP address
+  ## mountPath will be mounted in /socat{{ mountPath }} in both socat and HA pods
   devices:
     - name: zigbee-device
-      mountPath: /dev/zigbee
+      mountPath: /zigbee
       ip: ser2sock-zigbee.home-automation.svc
       port: 10000
 

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -65,17 +65,6 @@ ingress:
 
 hostNetwork: false
 
-cmdOverride:
-  enabled: false
-  shellArgs: "python -m homeassistant --config /config"
-  # default to run HA at least, more can be added by changing it to
-  #  "zha && zwave && python -m homeassistant --config /config"
-  #  zha/zwav are binaries mounted in /usr/bin inside the container using a confiMap
-  #
-  #  - "pty,link=/dev/ttyUSB0,raw,user=0,group=0,mode=777"
-  #  - "tcp:ser2sock.home-automation.svc:10000"
-  # Allows mounting of a ser2sock device via tcp
-
 persistence:
   enabled: true
   ## home-assistant data Persistent Volume Storage Class
@@ -332,6 +321,26 @@ appdaemon:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     # nodePort: 30000
+
+socat:
+  enabled: false
+  ## Can be used in conjunction with a ser2sock deployment to use serial
+  ## devices over IP. Currently only works with 1 device but ideally can be used
+  ## with multiple devices
+
+  ## socat container image
+  ##
+  image:
+    repository: alpine/socat
+    tag: 1.7.3.4-r0
+    pullPolicy: IfNotPresent
+
+  ## ip can be a domain name or actual IP address
+  devices:
+  - name: zigbee-device
+    mountPath: /dev/zigbee
+    ip: ser2sock-zigbee.home-automation.svc
+    port: 10000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -337,10 +337,10 @@ socat:
 
   ## ip can be a domain name or actual IP address
   devices:
-  - name: zigbee-device
-    mountPath: /dev/zigbee
-    ip: ser2sock-zigbee.home-automation.svc
-    port: 10000
+    - name: zigbee-device
+      mountPath: /dev/zigbee
+      ip: ser2sock-zigbee.home-automation.svc
+      port: 10000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/piaware/.helmignore
+++ b/charts/piaware/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/piaware/Chart.yaml
+++ b/charts/piaware/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: "3.8.1"
+description: Program for forwarding ADS-B data to FlightAware
+name: piaware
+version: 1.0.0
+keywords:
+  - piaware
+  - flight-aware
+  - flight-tracker
+home: https://github.com/billimek/billimek-charts/tree/master/charts/piaware
+icon: https://pbs.twimg.com/profile_images/964269455483088897/mr2UgvfG_400x400.jpg
+sources:
+  - https://github.com/flightaware/piaware
+maintainers:
+  - name: billimek
+    email: jeff@billimek.com

--- a/charts/piaware/OWNERS
+++ b/charts/piaware/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- billimek
+reviewers:
+- billimek

--- a/charts/piaware/README.md
+++ b/charts/piaware/README.md
@@ -1,0 +1,64 @@
+# piaware: Program for forwarding ADS-B data to FlightAware
+
+This is a helm chart for [piaware](https://github.com/flightaware/piaware)
+
+## TL;DR;
+
+```shell
+$ helm repo add billimek https://billimek.com/billimek-charts/
+$ helm install billimek/piaware
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release billimek/piaware
+```
+
+**IMPORTANT NOTE:** a flight-aware USB device must be accessible on the node where this pod runs, in order for this chart to function properly.
+
+A way to achieve this can be with nodeAffinity rules, for example:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - flight-aware
+```
+
+... where a node with an attached flight-aware USB device is labeled with `app: flight-aware`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/piaware/values.yaml) file. It has several commented out suggested values.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name my-release \
+  --set rtspPassword="nosecrets" \
+    billimek/piaware
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-release -f values.yaml stable/piaware
+```

--- a/charts/piaware/templates/NOTES.txt
+++ b/charts/piaware/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "piaware.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "piaware.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "piaware.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "piaware.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:5000 to use your application"
+  kubectl port-forward $POD_NAME 5000:5000
+{{- end }}

--- a/charts/piaware/templates/_helpers.tpl
+++ b/charts/piaware/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "piaware.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "piaware.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "piaware.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "piaware.labels" -}}
+app.kubernetes.io/name: {{ include "piaware.name" . }}
+helm.sh/chart: {{ include "piaware.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/piaware/templates/deployment.yaml
+++ b/charts/piaware/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "piaware.fullname" . }}
+  labels:
+{{ include "piaware.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: {{ .Values.strategyType }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "piaware.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "piaware.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- if .Values.timezone }}
+            - name: TZ
+              value: "{{ .Values.timezone }}"
+            {{- end }}
+            {{- if .Values.latitude }}
+            - name: LAT
+              value: "{{ .Values.latitude }}"
+            {{- end }}
+            {{- if .Values.longitude }}
+            - name: LONG
+              value: "{{ .Values.longitude }}"
+            {{- end }}
+            {{- if .Values.feederId }}
+            - name: FEEDER_ID
+              value: "{{ .Values.feederId }}"
+            {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.device }}
+              name: usb
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: usb
+          hostPath:
+            path: {{ .Values.device }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/piaware/templates/ingress.yaml
+++ b/charts/piaware/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "piaware.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "piaware.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/piaware/templates/service.yaml
+++ b/charts/piaware/templates/service.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "piaware.fullname" . }}
+  labels:
+{{ include "piaware.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+  selector:
+    app.kubernetes.io/name: {{ include "piaware.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/piaware/values.yaml
+++ b/charts/piaware/values.yaml
@@ -1,0 +1,82 @@
+# Default values for piaware.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
+image:
+  repository: mikenye/piaware
+  tag: v3.8.1
+  pullPolicy: IfNotPresent
+
+# timezone to run the service as
+# timezone: "America/New York"
+
+# feeder id of device
+# feederId: "c478b1c99-23d3-4376-1f82-47352a28cg37"
+
+# coordinates of device
+# latitude: "-73.14980"
+# longitude: "30.66783"
+
+# device where the flight-aware device can be accessed
+device: "/dev/bus/usb/001/004"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  labels: {}
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}

--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 appVersion: 1.19.1.2645-ccb6eb67e
 description: Plex Media Server
 name: plex
+<<<<<<< HEAD
 version: 1.6.1
+=======
+version: 1.6.0
+>>>>>>> [plex] Allow custom extraMount paths (#270)
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -210,7 +210,11 @@ spec:
             name: "extradata-{{ .name }}"
           {{- end }}
           {{-  range .Values.persistence.extraMounts }}
+<<<<<<< HEAD
           - mountPath: "/{{ .mountPath }}"
+=======
+          - mountPath: "/{{ .name }}"
+>>>>>>> [plex] Allow custom extraMount paths (#270)
             name: "{{ .name }}"
           {{- end }}
           - name: shared

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -212,10 +212,16 @@ persistence:
   extraMounts: []
     ## Include additional claims that can be mounted inside the
     ## pod. This is useful if you wish to use different paths with categories
+<<<<<<< HEAD
     ## Claim will me mounted as /{mountPath}
     # - name: video
     #   claimName: video-claim
     #   mountPath: mnt/path/in/pod
+=======
+    ## Claim will me mounted as /{name}
+    # - name: video
+    #   claimName: video-claim
+>>>>>>> [plex] Allow custom extraMount paths (#270)
 
   config:
     # Optionally specify claimName to manually override the PVC to be used for

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -212,16 +212,10 @@ persistence:
   extraMounts: []
     ## Include additional claims that can be mounted inside the
     ## pod. This is useful if you wish to use different paths with categories
-<<<<<<< HEAD
     ## Claim will me mounted as /{mountPath}
     # - name: video
     #   claimName: video-claim
     #   mountPath: mnt/path/in/pod
-=======
-    ## Claim will me mounted as /{name}
-    # - name: video
-    #   claimName: video-claim
->>>>>>> [plex] Allow custom extraMount paths (#270)
 
   config:
     # Optionally specify claimName to manually override the PVC to be used for

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,5 @@
 helm-extra-args: --timeout 600s
+check-version-increment: true
+debug: true
 chart-dirs:
   - charts
-chart-repos:
-  - dcplaya=https://github.com.com/dcplaya/billimek-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,6 @@
 helm-extra-args: --timeout 600s
 check-version-increment: true
 debug: true
-remote: HA-Sidecar
+target-branch: HA-Sidecar
 chart-dirs:
   - charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,4 +1,5 @@
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
-
+chart-repos:
+  - billimek=https://billimek.com/billimek-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,6 @@
 helm-extra-args: --timeout 600s
 check-version-increment: true
 debug: true
-target-branch: HA-Sidecar
+target-branch: adguard-home
 chart-dirs:
   - charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,5 @@
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
-chart-repos:
-  - billimek=https://billimek.com/billimek-charts
+#chart-repos:
+#  - billimek=https://billimek.com/billimek-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,5 @@
 helm-extra-args: --timeout 600s
-#CHECK_VERSION_INCREMENT: false
 chart-dirs:
   - charts
 chart-repos:
-  - billimek=https://billimek.com/billimek-charts
+  - dcplaya=https://github.com.com/dcplaya/billimek-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 helm-extra-args: --timeout 600s
 check-version-increment: true
 debug: true
+remote: HA-Sidecar
 chart-dirs:
   - charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 helm-extra-args: --timeout 600s
+#CHECK_VERSION_INCREMENT: false
 chart-dirs:
   - charts
-#chart-repos:
-#  - billimek=https://billimek.com/billimek-charts
+chart-repos:
+  - billimek=https://billimek.com/billimek-charts


### PR DESCRIPTION
#### Special notes for your reviewer:
Similar to Pi-Hole/Blocky. Has DHCP and DNS-over-TLS options but my home LAN isnt set up to test that so I am not sure it works. Standard DNS works and HTTP works as long as during setup, the port is set to the initial standard of 3000. Might be a more elegant way to be more dynamic but I couldn't think of one. 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
